### PR TITLE
Improvement for gracefully finish the writer script

### DIFF
--- a/gicisky_tag/writer.py
+++ b/gicisky_tag/writer.py
@@ -23,6 +23,10 @@ class ScreenWriter:
             await self.notify_handler(sender, data)
         await self.device.start_notify(ScreenWriter.REQUEST_CHARACTERISTIC, handler)
 
+    async def stop_notify(self):
+        logger.debug(f"Stop notify")
+        await self.device.stop_notify(ScreenWriter.REQUEST_CHARACTERISTIC)
+
     async def _send_request(self, data):
         logger.log(logging.NOTSET, f"Sending request message: {[data[i] for i in range(len(data))]}")
         self.pending_notify = asyncio.Event()
@@ -155,3 +159,4 @@ async def send_data_to_screen(address, image_data):
         await screen.request_block_size()
         await screen.request_write_screen()
         await screen.request_start_transfer()
+        await screen.stop_notify()


### PR DESCRIPTION
- Currently the execution that happens in notify handler is stuck when device disconnected
  - Move send logic out from handler
- And to really gracefully finish we should remove all notify handles
  - Call stop_notify() before disconnect