### PR TITLE
Fix write_gatt_char parameter for corebluetooth backend

### DIFF
--- a/gicisky_tag/writer.py
+++ b/gicisky_tag/writer.py
@@ -58,6 +58,8 @@ class ScreenWriter:
             logging.NOTSET,
             f"Sending request message: {[data[i] for i in range(len(data))]}",
         )
+        if not isinstance(data, bytes):
+            data = bytes(data)
         await self.device.write_gatt_char(
             ScreenWriter.REQUEST_CHARACTERISTIC,
             data,


### PR DESCRIPTION
corebluetooth backend expected bytes array parameter, otherwise it'll throw error

```
2025-03-16 03:17:59,990 - gicisky_tag - INFO - Sending request message: [1]
/Users/jim/Library/Caches/pypoetry/virtualenvs/eink-image-generator-4RHInFAK-py3.12/lib/python3.12/site-packages/bleak/backends/corebluetooth/client.py:320: UninitializedDeallocWarning: leaking an uninitialized object of type _NSPlaceholderData
  value = NSData.alloc().initWithBytes_length_(data, len(data))
Traceback (most recent call last):
  File "/Users/jim/jim/gicisky-tag/gicisky_tag/writer.py", line 61, in _send_request
    await self.device.write_gatt_char(
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/eink-image-generator-4RHInFAK-py3.12/lib/python3.12/site-packages/bleak/__init__.py", line 776, in write_gatt_char
    await self._backend.write_gatt_char(characteristic, data, response)
  File "/Users/jim/Library/Caches/pypoetry/virtualenvs/eink-image-generator-4RHInFAK-py3.12/lib/python3.12/site-packages/bleak/backends/corebluetooth/client.py", line 320, in write_gatt_char
    value = NSData.alloc().initWithBytes_length_(data, len(data))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: depythonifying unknown typespec 0x76
```